### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Embrace the Scrum Master challenge, and elevate your Agile expertise to new heights. Lead your team to success, inspire productivity, and foster a culture of continuous improvement. Remember, in the world of Agile, the journey is as rewarding as the destination!
 
 # Overview
-Scrum Master is a single-player game, currently in development, which makes learning Scrum fun. It is the goal of this game to make understanding Agile principles easier, by simulating the full Scrum cylce and introducing Agile concepts in an interactive and rewarding way. This demystifies Agile's more abstract ideas by placing them in a context where players will learn by doing.
+Scrum Master is a single-player game, currently in development, which makes learning Scrum fun. It is the goal of this game to make understanding Agile principles easier, by simulating the full Scrum cycle and introducing Agile concepts in an interactive and rewarding way. This demystifies Agile's more abstract ideas by placing them in a context where players will learn by doing.
 
 # Gameplay
 You are THE Scrum Master, you will take charge of a virtual development team and embark on a journey of iterative software development. Guided by the Scrum framework, you will lead your team through Sprints, directing them to complete tasks effectively and efficiently. Balancing the workload, optimizing resource allocation, and prioritizing user stories will be key to delivering high-quality increments within the time-boxed iterations.


### PR DESCRIPTION
## Summary
- correct "cylce" typo in the Overview section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68537d8dbbe8833097e6539347c60381